### PR TITLE
Update eslint rules to properly apply env automatically

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
         "browser": true,
         "es6": true
     },
+    "ignorePatterns": ["dist/**/*.js"],
     "extends": "eslint:recommended",
     "globals": {
         "Atomics": "readonly",
@@ -30,5 +31,11 @@
             "error",
             "always"
         ]
-    }
+    },
+    "overrides": [{
+        "files": ["./*.js"],
+        "env": {
+            "node": true
+        }
+    }]
 }

--- a/husky.config.js
+++ b/husky.config.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const runNPMLock = 'npm install --from-lock-file';
 
 module.exports = {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,3 @@
-/*eslint-env node */
-
 if(process.env.NODE_ENV === 'production' || process.env.NODE_ENV=== 'distribution') {
     module.exports = {
         plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-/*eslint-env node */
-
 const path = require('path');
 const Dotenv = require('dotenv-webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');


### PR DESCRIPTION
Removes the per-file specification of `env` being `node` for root config and excludes `dist` altogether.